### PR TITLE
Adds delivery.yaml for CDP

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,0 +1,26 @@
+version: "2017-12-27"
+pipeline:
+  - id: build
+    type: script
+    commands:
+      - desc: "Install Java, Maven and Docker"
+        cmd: |
+          apt-get update
+          apt-get install -y openjdk-8-jdk maven
+          curl -fLOsS https://delivery.cloud.zalando.com/utils/ensure-docker && sh ensure-docker && rm ensure-docker
+      - desc: "Build with Maven"
+        cmd: |
+          ./mvnw clean package
+      - desc: "Push Docker Image"
+        cmd: |
+          IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
+          if [[ ${IS_PR_BUILD} != "true" ]]
+          then
+            RELEASE_VERSION=$(git describe --tags --always --dirty)
+            IMAGE_TAG=${RELEASE_VERSION}
+          else
+            IMAGE_TAG=${CDP_BUILD_VERSION}
+          fi
+          IMAGE="registry-write.opensource.zalan.do/zmon/zmon-metric-cache:$IMAGE_TAG"
+          docker build --tag "$IMAGE" .
+          docker push "$IMAGE"


### PR DESCRIPTION
The manifest that defines build scenario with Zalando CDP. Produces a single artifact  - the docker image